### PR TITLE
feat: add Folia support to Paper and Spigot player plugin

### DIFF
--- a/player-plugin/plugin-paper/src/main/resources/plugin.yml
+++ b/player-plugin/plugin-paper/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: SimpleCloud-Player
 version: 1.0
 api-version: 1.13
 main: app.simplecloud.droplet.player.plugin.paper.PlayerPaperPlugin
+folia-supported: true
 
 libraries:
   - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0

--- a/player-plugin/plugin-spigot/src/main/resources/plugin.yml
+++ b/player-plugin/plugin-spigot/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: SimpleCloud-Player
 version: 1.0
 api-version: 1.13
 main: app.simplecloud.droplet.player.plugin.spigot.PlayerSpigotPlugin
+folia-supported: true
 
 libraries:
   - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0


### PR DESCRIPTION
This pull request adds support for Folia to the player plugin by adding `folia-supported: true` to the plugin ymls

### Changes:

* [`player-plugin/plugin-paper/src/main/resources/plugin.yml`](diffhunk://#diff-a5c317ffb296f273e38c03d9c911776b277b4870e985ad2dc7e198886708cf99R5): Added the `folia-supported: true` property to indicate that the Paper version of the plugin supports Folia.
* [`player-plugin/plugin-spigot/src/main/resources/plugin.yml`](diffhunk://#diff-af867458b07ebc7b9283fb4cad14162ddaf8b009ef39426383c386420e651d1bR5): Added the `folia-supported: true` property to indicate that the Spigot version of the plugin supports Folia.